### PR TITLE
Add webpack plugin to catch linting error at compile time.

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
+    "fork-ts-checker-webpack-plugin": "^6.5.0",
     "html-webpack-plugin": "^5.5.0",
     "husky": "^7.0.4",
     "lint-staged": "^12.3.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const { resolve } = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 const config = {
   mode: 'development',
@@ -65,6 +66,12 @@ const config = {
       favicon16: './public/favicon-16x16.png',
       favicon32: './public/favicon-32x32.png',
       manifest: './public/manifest.json'
+    }),
+    new ForkTsCheckerWebpackPlugin({
+      eslint: {
+        files: './src/**/*.{ts,tsx,js,jsx}'
+        // required - same as command `eslint ./src/**/*.{ts,tsx,js,jsx} --ext .ts,.tsx,.js,.jsx`
+      }
     })
   ]
 };


### PR DESCRIPTION
This PR will add a webpack plugin that will check linting errors at compile-time, so we can resolve those errors right away.