### PR TITLE
Move all the types to separate interface file.

### DIFF
--- a/src/lib/helpers/responsive.interface.ts
+++ b/src/lib/helpers/responsive.interface.ts
@@ -1,0 +1,28 @@
+import { ReactNode } from 'react';
+
+export interface ResponsiveShapeProps {
+  height: string[];
+  width: string[];
+  top: string[];
+  left: string[];
+  right: string[];
+  bottom: string[];
+  zIndex: string;
+  className: string;
+  children: ReactNode;
+  breakpoints: number[];
+  position: string;
+}
+
+export interface ShapeDivProps {
+  height: string;
+  width: string;
+  top: string;
+  left: string;
+  right: string;
+  bottom: string;
+  zIndex: string;
+  className: string;
+  children: ReactNode;
+  position: string;
+}

--- a/src/lib/helpers/responsive.tsx
+++ b/src/lib/helpers/responsive.tsx
@@ -1,33 +1,7 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useMediaQuery } from 'react-responsive';
 import styled from '@emotion/styled';
-
-type ResponsiveShapeProps = {
-  height: string[];
-  width: string[];
-  top: string[];
-  left: string[];
-  right: string[];
-  bottom: string[];
-  zIndex: string;
-  className: string;
-  children: ReactNode;
-  breakpoints: number[];
-  position: string;
-};
-
-type ShapeDivProps = {
-  height: string;
-  width: string;
-  top: string;
-  left: string;
-  right: string;
-  bottom: string;
-  zIndex: string;
-  className: string;
-  children: ReactNode;
-  position: string;
-};
+import { ResponsiveShapeProps, ShapeDivProps } from './responsive.interface';
 
 const ShapeDiv = ({
   children,

--- a/src/lib/shapes/arrow.tsx
+++ b/src/lib/shapes/arrow.tsx
@@ -2,19 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { arrowPath } from './data/arrowPath';
-
-type ArrowProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const Arrow = ({
   size,
@@ -27,7 +15,7 @@ export const Arrow = ({
   className = `anim-shape-arrow`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: ArrowProps) => {
+}: ShapeProps) => {
   const StyledArrow = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/base.tsx
+++ b/src/lib/shapes/base.tsx
@@ -1,21 +1,8 @@
-import React, { Fragment, ReactNode } from 'react';
+import React, { Fragment } from 'react';
 import { ResponsiveShape } from '../helpers/responsive';
 import { expandValues } from '../utils/utils';
 import { checkDim, checkNonDecreasing } from '../helpers/error';
-
-type BaseShapeProps = {
-  height: string | string[];
-  width: string | string[];
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  zIndex?: string;
-  className?: string;
-  children: ReactNode;
-  breakpoints?: number[];
-  position?: string;
-};
+import { BaseShapeProps } from './shapes.interface';
 
 export const BaseShape = ({
   children,

--- a/src/lib/shapes/circle.tsx
+++ b/src/lib/shapes/circle.tsx
@@ -1,19 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
-
-type CircleProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const Circle = ({
   size,
@@ -26,7 +14,7 @@ export const Circle = ({
   className = `anim-shape-circle`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: CircleProps) => {
+}: ShapeProps) => {
   const StyledCircle = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/circlegrid.tsx
+++ b/src/lib/shapes/circlegrid.tsx
@@ -2,19 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { parseSizeAsNum } from '../utils/utils';
-
-type CircleGridProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const CircleGrid = ({
   size,
@@ -27,7 +15,7 @@ export const CircleGrid = ({
   className = `anim-shape-circlegrid`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: CircleGridProps) => {
+}: ShapeProps) => {
   let widthNum = parseSizeAsNum(size);
   if (typeof widthNum === 'number') {
     widthNum = Math.trunc((173 / 127) * widthNum);

--- a/src/lib/shapes/cross.tsx
+++ b/src/lib/shapes/cross.tsx
@@ -2,19 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { crossPath } from './data/crossPath';
-
-type CrossProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const Cross = ({
   size,
@@ -27,7 +15,7 @@ export const Cross = ({
   className = `anim-shape-star`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: CrossProps) => {
+}: ShapeProps) => {
   const StyledCross = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/diamond.tsx
+++ b/src/lib/shapes/diamond.tsx
@@ -1,19 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
-
-type DiamondProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const Diamond = ({
   size,
@@ -26,7 +14,7 @@ export const Diamond = ({
   className = `anim-shape-diamond`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: DiamondProps) => {
+}: ShapeProps) => {
   const StyledDiamond = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/donut.tsx
+++ b/src/lib/shapes/donut.tsx
@@ -1,20 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
-
-type DonutProps = {
-  size: string | string[];
-  color: string;
-  width: string | string[];
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { DonutProps } from './shapes.interface';
 
 export const Donut = ({
   size,

--- a/src/lib/shapes/message.tsx
+++ b/src/lib/shapes/message.tsx
@@ -2,21 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { messagePath } from './data/messagePath';
-
-type MessageProps = {
-  size: string | string[];
-  color: string;
-  height: string | string[];
-  width: string | string[];
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeWithSize } from './shapes.interface';
 
 export const Message = ({
   color,
@@ -30,7 +16,7 @@ export const Message = ({
   zIndex = `-1`,
   breakpoints = [600, 900, 1200],
   position = `absolute`
-}: MessageProps) => {
+}: ShapeWithSize) => {
   const StyledMessage = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/polygon.tsx
+++ b/src/lib/shapes/polygon.tsx
@@ -2,21 +2,7 @@ import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { clipPathMap } from './data/polygonClipPath';
-
-type PolygonProps = {
-  color: string;
-  height: string | string[];
-  width: string | string[];
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-  sides?: number;
-};
+import { PolygonProps } from './shapes.interface';
 
 export const Polygon = ({
   width,

--- a/src/lib/shapes/polygonCard.tsx
+++ b/src/lib/shapes/polygonCard.tsx
@@ -1,21 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
-
-type PolygonCardProps = {
-  size: string | string[];
-  color: string;
-  height: string | string[];
-  width: string | string[];
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeWithSize } from './shapes.interface';
 
 export const PolygonCard = ({
   width,
@@ -29,7 +15,7 @@ export const PolygonCard = ({
   className = `anim-shape-polygoncard`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: PolygonCardProps) => {
+}: ShapeWithSize) => {
   const StyledPolygonCard = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/shapes.interface.ts
+++ b/src/lib/shapes/shapes.interface.ts
@@ -36,9 +36,7 @@ export interface BaseShapeProps extends CommonProps, SizeProps {
   children: ReactNode;
 }
 
-export interface DonutProps extends ShapeProps {
-  width: string | string[];
-}
+export interface DonutProps extends ShapeProps, Pick<SizeProps, 'width'> {}
 
 export interface PolygonProps extends CommonProps, SizeProps {
   sides?: number;

--- a/src/lib/shapes/shapes.interface.ts
+++ b/src/lib/shapes/shapes.interface.ts
@@ -1,0 +1,46 @@
+import { ReactNode } from 'react';
+
+/**
+ * It has all the common props which required to all the shapes
+ */
+export interface CommonProps {
+  top?: string | string[];
+  left?: string | string[];
+  right?: string | string[];
+  bottom?: string | string[];
+  className?: string;
+  zIndex?: string;
+  breakpoints?: number[];
+  position?: string;
+}
+
+export interface SizeProps {
+  height: string | string[];
+  width: string | string[];
+}
+
+/**
+ * This interface is used for the shape which required additional props along with CommonProps
+ */
+export interface ShapeProps extends CommonProps {
+  size: string | string[];
+  color: string;
+}
+
+/**
+ * This interface is used for the shape which required additional props along with ShapeProps
+ */
+export interface ShapeWithSize extends ShapeProps, SizeProps {}
+
+export interface BaseShapeProps extends CommonProps, SizeProps {
+  children: ReactNode;
+}
+
+export interface DonutProps extends ShapeProps {
+  width: string | string[];
+}
+
+export interface PolygonProps extends CommonProps, SizeProps {
+  sides?: number;
+  color: string;
+}

--- a/src/lib/shapes/squareDonut.tsx
+++ b/src/lib/shapes/squareDonut.tsx
@@ -2,19 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { squareDonutPath } from './data/squareDonutPath';
-
-type SquareDonutProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const SquareDonut = ({
   size,
@@ -27,7 +15,7 @@ export const SquareDonut = ({
   className = `anim-shape-square-donut`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: SquareDonutProps) => {
+}: ShapeProps) => {
   const StyledSquareDonut = styled('div')`
     position: inherit;
     height: inherit;

--- a/src/lib/shapes/star.tsx
+++ b/src/lib/shapes/star.tsx
@@ -2,19 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { BaseShape } from './base';
 import { starPath } from './data/starPath';
-
-type StarProps = {
-  size: string | string[];
-  color: string;
-  top?: string | string[];
-  left?: string | string[];
-  right?: string | string[];
-  bottom?: string | string[];
-  className?: string;
-  zIndex?: string;
-  breakpoints?: number[];
-  position?: string;
-};
+import { ShapeProps } from './shapes.interface';
 
 export const Star = ({
   size,
@@ -27,7 +15,7 @@ export const Star = ({
   className = `anim-shape-star`,
   zIndex = `-1`,
   breakpoints = [600, 900, 1200]
-}: StarProps) => {
+}: ShapeProps) => {
   const StyledStar = styled('div')`
     position: inherit;
     height: inherit;


### PR DESCRIPTION
Move the all the types to its separate interface file for better readability and re-usability.
Closes #75 

@ashutosh1919 @Sachin-chaurasiya 